### PR TITLE
Update bootstrap links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -214,6 +214,10 @@ aside h2 {
   opacity: 0;
 }
 
+.note_text {
+    font-size: 16px;
+}
+
 /* TAKE HOME */
 .take-home ul li a {
     font-weight: bold;

--- a/eight.html
+++ b/eight.html
@@ -90,7 +90,7 @@
       </aside>
       <main class="col-9">
         <ul class="points">
-          <li><a href="https://getbootstrap.com/docs/4.1/content/tables/#examples" target="_blank">Bootstrap Tables</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/content/tables/" target="_blank">Bootstrap Tables</a></li>
         </ul>
       </main>
     </div>

--- a/eleven.html
+++ b/eleven.html
@@ -91,7 +91,7 @@
           <ul class="nested-points">
             <li><a href="https://www.mugo.ca/Blog/7-benefits-of-using-SASS-over-conventional-CSS" target="_blank">What is Sass?</a></li>
             <li><a href="https://marksheet.io/sass-scss-less.html" target="_blank">sass vs scss</a></li>
-            <li><a href="https://getbootstrap.com/docs/4.5/getting-started/theming/" target="_blank">Sass in Bootstrap</a></li>
+            <li><a href="https://getbootstrap.com/docs/5.1/customize/sass/" target="_blank">Sass in Bootstrap</a></li>
             <li><a href="https://www.sassmeister.com/" target="_blank">Sassmeister</a> - sass playground</li>
             <li><a href="https://inspirationalpixels.com/sass-projects-for-beginners-1/" target="_blank">Beginner's Guide to Set Up</a></li>
           </ul>

--- a/five.html
+++ b/five.html
@@ -116,15 +116,47 @@
 
     <div class="row section">
       <aside class="col">
+        <h2>Introduction to Bootstrap Utilities and Typography</h2>
+      </aside>
+      <main class="col-9">
+        <ul class="points">
+          <li>
+            <a href="https://getbootstrap.com/docs/5.1/content/typography/">Typography</a>
+          </li>
+          <hr/>
+          <li><a href="https://getbootstrap.com/docs/5.1/utilities/background/" target="_blank">Background</a></li>
+          <li>
+            <a href="https://getbootstrap.com/docs/5.1/utilities/borders/" target="_blank">Borders and Radius</a>
+          </li>
+          <li>
+            <a href="https://getbootstrap.com/docs/5.1/utilities/colors/" target="_blank">Colors</a>
+          </li>
+          <li>
+            <a href="https://getbootstrap.com/docs/5.1/utilities/spacing/" target="_blank">Spacing (margin and padding)</a>
+          </li>
+          <li><a href="https://getbootstrap.com/docs/5.1/utilities/text/" target="_blank">Text</a></li>
+          <li>
+            <span class="bolder">*BONUS* <a href="https://getbootstrap.com/docs/5.1/components/buttons/" target="_blank">Buttons</a></span>
+          </li>
+        </ul>
+      </main>
+    </div>
+    <div class="row section">
+      <aside class="col">
         <h2>Bootstrap Jumbotron</h2>
       </aside>
       <main class="col-9">
         <ul class="points">
-          <li><a href="https://getbootstrap.com/docs/4.5/components/jumbotron/" target="_blank">Jumbotron Documentation</a></li>
+          <li>
+            <a href="https://www.w3schools.com/bootstrap/bootstrap_jumbotron_header.asp">What is a Jumbotron?</a>
+            <p class="note_text">* In Bootstrap v5.1 there is no longer a class of <code>.jumbotron</code>, instead use utilities to build a custom jumbotron *</p>
+          </li>
+          <li>
+            <a href="https://getbootstrap.com/docs/5.1/examples/jumbotron/">Jumbotron Example</a>
+          </li>
         </ul>
       </main>
     </div>
-
     <div class="row section">
       <aside class="col">
         <h2>Take Home Challenge</h2>
@@ -135,7 +167,7 @@
           <ul class="nested-points">
             <li>Pull all changes to master branch</li>
             <li>Create a new branch called "jumbotron"</li>
-            <li>Using the Bootstrap example, add a jumbotron to the index file</li>
+            <li>Using the Bootstrap example as a guide, add a jumbotron to the index file using utilities from today's lesson</li>
             <li>Add, commit and push your changes to your jumbotron branch</li>
             <li>Open a new pull request for your jumbotron branch</li>
             <li>Request Review from your collaborator</li>

--- a/four.html
+++ b/four.html
@@ -136,8 +136,8 @@
       </aside>
       <main class="col-9">
         <ul class="points">
-          <li><a href="https://getbootstrap.com/docs/4.5/layout/overview/#containers" target="_blank">Containers</a></li>
-          <li><a href="https://getbootstrap.com/docs/4.5/layout/grid/" target="_blank">Grid</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/layout/containers/" target="_blank">Containers</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/layout/grid/" target="_blank">Grid</a></li>
         </ul>
       </main>
     </div>

--- a/nine.html
+++ b/nine.html
@@ -89,7 +89,7 @@
       <main class="col-9">
         <ul class="points">
           <li>Requires Bootstrap js dependencies</li>
-          <li><a href="https://getbootstrap.com/docs/4.0/components/carousel/" target="_blank">Bootstrap Carousel</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/components/carousel/" target="_blank">Bootstrap Carousel</a></li>
         </ul>
       </main>
     </div>
@@ -130,7 +130,7 @@
       <main class="col-9">
         <ul class="points">
           <li>Requires Bootstrap js dependencies</li>
-          <li><a href="https://getbootstrap.com/docs/4.0/components/navs/#javascript-behavior" target="_blank">Bootstrap Nav Tabs</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/components/navs-tabs/" target="_blank">Bootstrap Nav Tabs</a></li>
         </ul>
       </main>
     </div>

--- a/seven.html
+++ b/seven.html
@@ -91,7 +91,7 @@
       <main class="col-9">
         <ul class="points">
           <li><a href="https://www.mockplus.com/blog/post/hamburger-menu-examples" target="_blank">Hamburger Menu Examples</a></li>
-          <li><a href="https://getbootstrap.com/docs/4.5/components/navbar/" target="_blank">Bootstrap Responsive Navbar</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/components/navbar/" target="_blank">Bootstrap Responsive Navbar</a></li>
           <li>Linking nav items to a page section</li>
         </ul>
       </main>

--- a/six.html
+++ b/six.html
@@ -86,30 +86,25 @@
 
     <div class="row section">
       <aside class="col">
-        <h2>Utility CLasses</h2>
+        <h2>More Utility CLasses</h2>
       </aside>
       <main class="col-9">
         <ul class="points">
-          <li><a href="https://getbootstrap.com/docs/4.5/utilities/borders/" target="_blank">Utility Class Documentation</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/utilities/display/" target="_blank">Utility Class Documentation</a></li>
           <ul class="nested-points">
-            <li>Borders</li>
-            <li>Colors</li>
             <li>Display</li>
             <li>Flex</li>
             <li>Position</li>
             <li>Screen Readers</li>
             <li>Shadows</li>
             <li>Sizing</li>
-            <li>Spacing</li>
-            <li>Text</li>
             <li>Vertical Alignment</li>
             <li>Visibility</li>
           </ul>
-          <li>Other classes:</li>
+          <li>Content classes:</li>
           <ul class="nested-points">
-            <li><a href="https://getbootstrap.com/docs/4.5/content/typography/" target="_blank">Typography</a></li>
-            <li><a href="https://getbootstrap.com/docs/4.5/content/code/" target="_blank">Code</a></li>
-            <li><a href="https://getbootstrap.com/docs/4.5/content/images/" target="_blank">Images</a></li>
+            <li><a href="https://getbootstrap.com/docs/5.1/content/reboot/#inline-code" target="_blank">Code</a></li>
+            <li><a href="https://getbootstrap.com/docs/5.1/content/images/" target="_blank">Images</a></li>
           </ul>
         </ul>
       </main>

--- a/ten.html
+++ b/ten.html
@@ -117,7 +117,7 @@
       </aside>
       <main class="col-9">
         <ul class="points">
-          <li><a href="https://getbootstrap.com/docs/4.0/components/forms/" target="_blank">Bootstrap Forms</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/forms/overview/" target="_blank">Bootstrap Forms</a></li>
         </ul>
       </main>
     </div>

--- a/three.html
+++ b/three.html
@@ -102,11 +102,11 @@
               <li>Does not require internet connection</li>
             </ul>
           </ul>
-          <li><a href="https://getbootstrap.com/docs/4.5/getting-started/download/" target="_blank">Download Bootstrap</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/getting-started/download/" target="_blank">Download Bootstrap</a></li>
           <ul class="nested-points">
             <li>Minified Files</li>
           </ul>
-          <li><a href="https://getbootstrap.com/docs/4.5/getting-started/introduction/#starter-template" target="_blank">Bootstrap Starter Template</a></li>
+          <li><a href="https://getbootstrap.com/docs/5.1/getting-started/introduction/#starter-template" target="_blank">Bootstrap Starter Template</a></li>
         </ul>
       </main>
     </div>


### PR DESCRIPTION
## Changes
_Updated links regarding Bootstrap to newest stable version 5.1_

- Updated links
- Made changes to the Jumbotron section due to Bootstrap dropping the `.jumbotron` class. Instead, introduced some Utility classes early that will help construct a Jumbotron from scratch.